### PR TITLE
Render random terrain with WebGL

### DIFF
--- a/main.html
+++ b/main.html
@@ -17,10 +17,15 @@
         alert('WebGL not supported');
       }
 
+      canvas.width = canvas.clientWidth;
+      canvas.height = canvas.clientHeight;
+      gl.viewport(0, 0, canvas.width, canvas.height);
+
       const vertexShaderSource = `
-        attribute vec2 position;
+        attribute vec3 position;
+        uniform mat4 uMatrix;
         void main() {
-          gl_Position = vec4(position, 0.0, 1.0);
+          gl_Position = uMatrix * vec4(position, 1.0);
         }
       `;
 
@@ -38,35 +43,117 @@
         return shader;
       }
 
-      const vertexShader = createShader(gl, gl.VERTEX_SHADER, vertexShaderSource);
-      const fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderSource);
-
-      const program = gl.createProgram();
-      gl.attachShader(program, vertexShader);
-      gl.attachShader(program, fragmentShader);
-      gl.linkProgram(program);
-      gl.useProgram(program);
-
-      const points = [];
-      const segments = 100;
-      for (let i = 0; i <= segments; i++) {
-        const x = (i / segments) * 2 - 1;
-        const y = Math.random() * 0.5 - 0.5;
-        points.push(x, -1.0);
-        points.push(x, y);
+      function createProgram(gl, vertexShader, fragmentShader) {
+        const program = gl.createProgram();
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+        return program;
       }
 
-      const buffer = gl.createBuffer();
-      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(points), gl.STATIC_DRAW);
+      const vertexShader = createShader(gl, gl.VERTEX_SHADER, vertexShaderSource);
+      const fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderSource);
+      const program = createProgram(gl, vertexShader, fragmentShader);
+      gl.useProgram(program);
+
+      const size = 32;
+      const vertices = [];
+      for (let z = 0; z < size; z++) {
+        for (let x = 0; x < size; x++) {
+          const xPos = (x / (size - 1)) * 2 - 1;
+          const zPos = (z / (size - 1)) * 2 - 1;
+          const yPos = Math.random() * 0.3;
+          vertices.push(xPos, yPos, zPos);
+        }
+      }
+
+      const indices = [];
+      for (let z = 0; z < size - 1; z++) {
+        for (let x = 0; x < size - 1; x++) {
+          const topLeft = z * size + x;
+          const topRight = topLeft + 1;
+          const bottomLeft = topLeft + size;
+          const bottomRight = bottomLeft + 1;
+          indices.push(topLeft, bottomLeft, topRight);
+          indices.push(topRight, bottomLeft, bottomRight);
+        }
+      }
+
+      const positionBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.STATIC_DRAW);
+
+      const indexBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+      gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
 
       const positionLocation = gl.getAttribLocation(program, 'position');
       gl.enableVertexAttribArray(positionLocation);
-      gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+      gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, 0, 0);
 
+      function subtract(a, b) { return [a[0]-b[0], a[1]-b[1], a[2]-b[2]]; }
+      function normalize(v) {
+        const len = Math.hypot(v[0], v[1], v[2]);
+        return len > 0.00001 ? [v[0]/len, v[1]/len, v[2]/len] : [0,0,0];
+      }
+      function cross(a, b) {
+        return [a[1]*b[2]-a[2]*b[1], a[2]*b[0]-a[0]*b[2], a[0]*b[1]-a[1]*b[0]];
+      }
+      function dot(a, b) { return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]; }
+
+      function lookAt(camera, target, up) {
+        const zAxis = normalize(subtract(camera, target));
+        const xAxis = normalize(cross(up, zAxis));
+        const yAxis = cross(zAxis, xAxis);
+        return [
+          xAxis[0], yAxis[0], zAxis[0], 0,
+          xAxis[1], yAxis[1], zAxis[1], 0,
+          xAxis[2], yAxis[2], zAxis[2], 0,
+          -dot(xAxis, camera),
+          -dot(yAxis, camera),
+          -dot(zAxis, camera),
+          1
+        ];
+      }
+
+      function perspective(fovy, aspect, near, far) {
+        const f = 1.0 / Math.tan(fovy / 2);
+        const nf = 1 / (near - far);
+        return [
+          f / aspect, 0, 0, 0,
+          0, f, 0, 0,
+          0, 0, (far + near) * nf, -1,
+          0, 0, (2 * far * near) * nf, 0
+        ];
+      }
+
+      function multiply(a, b) {
+        const out = new Array(16);
+        for (let i = 0; i < 4; ++i) {
+          const ai0 = a[i], ai1 = a[i + 4], ai2 = a[i + 8], ai3 = a[i + 12];
+          out[i]      = ai0 * b[0]  + ai1 * b[1]  + ai2 * b[2]  + ai3 * b[3];
+          out[i + 4]  = ai0 * b[4]  + ai1 * b[5]  + ai2 * b[6]  + ai3 * b[7];
+          out[i + 8]  = ai0 * b[8]  + ai1 * b[9]  + ai2 * b[10] + ai3 * b[11];
+          out[i + 12] = ai0 * b[12] + ai1 * b[13] + ai2 * b[14] + ai3 * b[15];
+        }
+        return out;
+      }
+
+      const aspect = canvas.clientWidth / canvas.clientHeight;
+      const projectionMatrix = perspective(Math.PI / 4, aspect, 0.1, 10);
+      const cameraPosition = [1.5, 1.5, 1.5];
+      const target = [0, 0, 0];
+      const up = [0, 1, 0];
+      const viewMatrix = lookAt(cameraPosition, target, up);
+      const matrix = multiply(projectionMatrix, viewMatrix);
+
+      const matrixLocation = gl.getUniformLocation(program, 'uMatrix');
+      gl.uniformMatrix4fv(matrixLocation, false, new Float32Array(matrix));
+
+      gl.enable(gl.DEPTH_TEST);
       gl.clearColor(0.0, 0.0, 0.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
-      gl.drawArrays(gl.TRIANGLE_STRIP, 0, points.length / 2);
+      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+      gl.drawElements(gl.TRIANGLES, indices.length, gl.UNSIGNED_SHORT, 0);
     </script>
   </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -1,7 +1,72 @@
+<!DOCTYPE html>
 <html>
-    <body>
-        <canvas id="moonLanderCanvas">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Moon Lander</title>
+    <style>
+      html, body { margin: 0; height: 100%; }
+      #moonLanderCanvas { width: 100%; height: 100%; display: block; }
+    </style>
+  </head>
+  <body>
+    <canvas id="moonLanderCanvas"></canvas>
+    <script>
+      const canvas = document.getElementById('moonLanderCanvas');
+      const gl = canvas.getContext('webgl');
+      if (!gl) {
+        alert('WebGL not supported');
+      }
 
-        </canvas>
-    </body>
+      const vertexShaderSource = `
+        attribute vec2 position;
+        void main() {
+          gl_Position = vec4(position, 0.0, 1.0);
+        }
+      `;
+
+      const fragmentShaderSource = `
+        precision mediump float;
+        void main() {
+          gl_FragColor = vec4(0.4, 0.8, 0.1, 1.0);
+        }
+      `;
+
+      function createShader(gl, type, source) {
+        const shader = gl.createShader(type);
+        gl.shaderSource(shader, source);
+        gl.compileShader(shader);
+        return shader;
+      }
+
+      const vertexShader = createShader(gl, gl.VERTEX_SHADER, vertexShaderSource);
+      const fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderSource);
+
+      const program = gl.createProgram();
+      gl.attachShader(program, vertexShader);
+      gl.attachShader(program, fragmentShader);
+      gl.linkProgram(program);
+      gl.useProgram(program);
+
+      const points = [];
+      const segments = 100;
+      for (let i = 0; i <= segments; i++) {
+        const x = (i / segments) * 2 - 1;
+        const y = Math.random() * 0.5 - 0.5;
+        points.push(x, -1.0);
+        points.push(x, y);
+      }
+
+      const buffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(points), gl.STATIC_DRAW);
+
+      const positionLocation = gl.getAttribLocation(program, 'position');
+      gl.enableVertexAttribArray(positionLocation);
+      gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+
+      gl.clearColor(0.0, 0.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, points.length / 2);
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Set up WebGL canvas and shaders in `main.html`
- Generate random terrain segments and render them as a triangle strip

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c282535c8328817f886efe8533ab