### PR TITLE
Add lighting and smooth high-resolution terrain

### DIFF
--- a/main.html
+++ b/main.html
@@ -23,16 +23,22 @@
 
       const vertexShaderSource = `
         attribute vec3 position;
+        attribute vec3 normal;
         uniform mat4 uMatrix;
+        varying float vLight;
         void main() {
           gl_Position = uMatrix * vec4(position, 1.0);
+          vec3 lightDir = normalize(vec3(0.5, 1.0, 0.5));
+          vLight = max(dot(normal, lightDir), 0.0);
         }
       `;
 
       const fragmentShaderSource = `
         precision mediump float;
+        varying float vLight;
         void main() {
-          gl_FragColor = vec4(0.4, 0.8, 0.1, 1.0);
+          vec3 color = vec3(0.4, 0.8, 0.1) * (0.2 + 0.8 * vLight);
+          gl_FragColor = vec4(color, 1.0);
         }
       `;
 
@@ -56,13 +62,15 @@
       const program = createProgram(gl, vertexShader, fragmentShader);
       gl.useProgram(program);
 
-      const size = 32;
+      const size = 100;
       const vertices = [];
       for (let z = 0; z < size; z++) {
         for (let x = 0; x < size; x++) {
           const xPos = (x / (size - 1)) * 2 - 1;
           const zPos = (z / (size - 1)) * 2 - 1;
-          const yPos = Math.random() * 0.3;
+          const yPos =
+            Math.sin(x * 0.3) * Math.cos(z * 0.3) * 0.1 +
+            (Math.random() - 0.5) * 0.02;
           vertices.push(xPos, yPos, zPos);
         }
       }
@@ -79,17 +87,47 @@
         }
       }
 
+      const normals = new Array(vertices.length).fill(0);
+      for (let i = 0; i < indices.length; i += 3) {
+        const ia = indices[i] * 3;
+        const ib = indices[i + 1] * 3;
+        const ic = indices[i + 2] * 3;
+        const a = [vertices[ia], vertices[ia + 1], vertices[ia + 2]];
+        const b = [vertices[ib], vertices[ib + 1], vertices[ib + 2]];
+        const c = [vertices[ic], vertices[ic + 1], vertices[ic + 2]];
+        const ab = subtract(b, a);
+        const ac = subtract(c, a);
+        const n = cross(ab, ac);
+        normals[ia] += n[0]; normals[ia + 1] += n[1]; normals[ia + 2] += n[2];
+        normals[ib] += n[0]; normals[ib + 1] += n[1]; normals[ib + 2] += n[2];
+        normals[ic] += n[0]; normals[ic + 1] += n[1]; normals[ic + 2] += n[2];
+      }
+      for (let i = 0; i < normals.length; i += 3) {
+        const n = normalize([normals[i], normals[i + 1], normals[i + 2]]);
+        normals[i] = n[0]; normals[i + 1] = n[1]; normals[i + 2] = n[2];
+      }
+
       const positionBuffer = gl.createBuffer();
       gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
       gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.STATIC_DRAW);
+
+      const normalBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(normals), gl.STATIC_DRAW);
 
       const indexBuffer = gl.createBuffer();
       gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
       gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
 
       const positionLocation = gl.getAttribLocation(program, 'position');
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
       gl.enableVertexAttribArray(positionLocation);
       gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, 0, 0);
+
+      const normalLocation = gl.getAttribLocation(program, 'normal');
+      gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+      gl.enableVertexAttribArray(normalLocation);
+      gl.vertexAttribPointer(normalLocation, 3, gl.FLOAT, false, 0, 0);
 
       function subtract(a, b) { return [a[0]-b[0], a[1]-b[1], a[2]-b[2]]; }
       function normalize(v) {


### PR DESCRIPTION
## Summary
- Introduce directional light and shading to highlight terrain height.
- Increase terrain grid to 100x100 and use sine-based heights for smoother elevation changes.
- Compute vertex normals and send them to shaders for lighting.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc632b18832885118e517d2ff172